### PR TITLE
chore(ci): add Dependabot for cargo and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # Rust crate dependencies (Cargo.toml / Cargo.lock)
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used in workflows (.github/workflows/*)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions-all:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml` to track latest dependency versions.

## What it does
- **cargo** — weekly updates for Rust crate deps (`Cargo.toml`/`Cargo.lock`). Minor/patch bumps grouped into one PR; major bumps separate for individual review. Commits prefixed `deps`.
- **github-actions** — weekly updates for action versions in `ci.yml`/`release.yml` (e.g. `actions/checkout`). All grouped into one PR. Commits prefixed `ci`.

Skipped the `pip` ecosystem since `pyproject.toml` has `dependencies = []` (only optional `torch`/`numpy` test extras).

Dependabot activates automatically once this merges to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)