### PR TITLE
release: v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-dlpack"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["isPANN"]
 description = "Zero-copy DLPack tensor interop for PyO3"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/pyo3-dlpack"
 readme = "README.md"
 keywords = ["dlpack", "pyo3", "tensor", "pytorch", "numpy"]
 categories = ["development-tools::ffi", "science"]
-rust-version = "1.70"
+rust-version = "1.83"
 
 [dependencies]
 pyo3 = { version = "0.28", default-features = false }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ the [DLPack](https://github.com/dmlc/dlpack) protocol.
 ## Features
 
 - **Zero-copy**: Tensors are shared directly without copying data
-- **PyO3 0.27+**: Uses the modern API (no deprecation warnings)
+- **PyO3 0.28+**: Uses the modern API (no deprecation warnings)
 - **Bidirectional**: Import tensors from Python and export tensors to Python
 - **Device-agnostic**: Works with CPU, CUDA, ROCm, and other devices
 
@@ -19,8 +19,8 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-pyo3-dlpack = "0.1"
-pyo3 = "0.27"
+pyo3-dlpack = "0.2"
+pyo3 = "0.28"
 ```
 
 ## Usage

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -261,7 +261,7 @@ impl DLDataType {
 
     /// Get the size of one element in bytes.
     pub fn itemsize(&self) -> usize {
-        ((self.bits as usize) * (self.lanes as usize) + 7) / 8
+        ((self.bits as usize) * (self.lanes as usize)).div_ceil(8)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! ## Features
 //!
 //! - **Zero-copy**: Tensors are shared directly without copying data
-//! - **PyO3 0.23+**: Uses the modern `IntoPyObject` trait (no deprecation warnings)
+//! - **PyO3 0.28+**: Uses the modern `IntoPyObject` trait (no deprecation warnings)
 //! - **Bidirectional**: Import tensors from Python and export tensors to Python
 //! - **Device-agnostic**: Works with CPU, CUDA, ROCm, and other devices
 //!


### PR DESCRIPTION
Prepares the **v0.2.0** release.

## Changes
- Bump crate version `0.1.0` → `0.2.0`. This is a minor (breaking) bump per semver for `0.x` crates, because the [pyo3 0.27→0.28 upgrade (#4)](https://github.com/isPANN/pyo3-dlpack/pull/4) is breaking for downstream consumers — pyo3 types appear in the public API, so users must move to pyo3 0.28.
- Bump `rust-version` (MSRV) `1.70` → `1.83`, matching pyo3 0.28's MSRV.
- Update README and crate docs to reference pyo3 0.28 / `pyo3-dlpack = "0.2"`.

## Release process
Once this is merged, pushing the `v0.2.0` tag triggers the Release workflow:
- Verifies the tag matches `Cargo.toml`
- `cargo publish` to crates.io
- Creates a GitHub release with auto-generated notes

Verified locally with `cargo publish --dry-run` (packages + verifies v0.2.0 successfully).

🤖 Generated with [Claude Code](https://claude.com/claude-code)