### PR TITLE
chore: add CHANGELOG and version-stability CI gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,32 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+  msrv:
+    name: MSRV (1.83)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@1.83
+      - uses: Swatinem/rust-cache@v2
+      # Check the library against the declared rust-version in Cargo.toml.
+      # Dev-dependencies (criterion) may require a newer toolchain, so we
+      # deliberately scope this to the public crate, not --all-targets.
+      - name: Cargo check (all features)
+        run: cargo check --all-features
+
+  semver:
+    name: Semver checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # Compares the current API surface against the latest version published
+      # on crates.io and fails if the change is more breaking than the version
+      # bump implies. Prevents accidental breaking changes in patch/minor releases.
+      - name: Check semver compatibility
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+
   test:
     name: Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+> **Note on `pyo3`:** `pyo3` is a *public dependency* — its types (`Python`,
+> `Bound<'_, PyAny>`, `PyResult`, `PyCapsule`, …) appear in this crate's public
+> API. Your project must use the **same `pyo3` minor version** as `pyo3-dlpack`,
+> and every breaking `pyo3` release forces a breaking release here.
+>
+> | pyo3-dlpack | pyo3   |
+> | ----------- | ------ |
+> | 0.2.x       | 0.28   |
+> | 0.1.x       | 0.27   |
+
+## [Unreleased]
+
+### Added
+- `CHANGELOG.md` following the Keep a Changelog format.
+- CI: MSRV job (Rust 1.83) verifying the crate builds on the declared
+  `rust-version`.
+- CI: `cargo-semver-checks` job that compares the API surface against the
+  latest crates.io release and fails on undeclared breaking changes.
+
+## [0.2.0] - 2026-05-29
+
+### Changed
+- **Breaking:** upgraded `pyo3` from `0.27` to `0.28` and adapted to its
+  breaking changes. Because `pyo3` is a public dependency, consumers must
+  upgrade their own `pyo3` to `0.28` in lockstep.
+- **Breaking:** raised the minimum supported Rust version (MSRV) from `1.70`
+  to `1.83`.
+
+### Fixed
+- Use `div_ceil` for itemsize calculation (clippy lint).
+
+### Internal
+- Added Dependabot configuration for `cargo` and `github-actions`.
+
+## [0.1.0] - 2026-01-30
+
+### Added
+- Initial release: zero-copy DLPack tensor interop for PyO3 (`pyo3` 0.27).
+- Import tensors from Python via `PyTensor::from_pyany` / `from_capsule`,
+  with capsule lifetime management and double-free protection (`dltensor` →
+  `used_dltensor` rename on consume).
+- Export Rust tensors to Python via the `IntoDLPack` trait and `TensorInfo`
+  (contiguous and strided layouts, byte-offset support).
+- `#[repr(C)]` FFI types mirroring the DLPack ABI (`DLTensor`,
+  `DLManagedTensor`, `DLDevice`, `DLDataType`) with struct-layout tests.
+- Convenience constructors for dtypes (f16/f32/f64/bf16, i8–i64, u8–u64, bool)
+  and devices (CPU, CUDA, CUDA host, ROCm, Metal, Vulkan, …).
+- Rust (criterion) and Python benchmarks; unit + integration test suite.
+
+[Unreleased]: https://github.com/isPANN/pyo3-dlpack/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/isPANN/pyo3-dlpack/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/isPANN/pyo3-dlpack/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Raised the `pytest` floor in the `test`/`test-lite` extras from `>=7.0` to
+  `>=9.0.3` to exclude versions affected by CVE-2025-71176 (tmpdir handling)
+  and pull in a patched `Pygments` (CVE-2026-4539). Test-only dependencies —
+  not shipped with the published crate.
+
 ### Added
 - `CHANGELOG.md` following the Keep a Changelog format.
 - CI: MSRV job (Rust 1.83) verifying the crate builds on the declared

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,13 +12,13 @@ dependencies = []
 [project.optional-dependencies]
 test = [
     "maturin>=1.4,<2.0",
-    "pytest>=7.0",
+    "pytest>=9.0.3",
     "torch>=2.0",
     "numpy>=1.20",
 ]
 test-lite = [
     "maturin>=1.4,<2.0",
-    "pytest>=7.0",
+    "pytest>=9.0.3",
     "numpy>=1.20",
 ]
 


### PR DESCRIPTION
## What & why

Closes the gap around release stability raised in discussion: this crate's public API is bounded by `pyo3` (a public dependency), and we had no automated guard against accidental breaking changes or MSRV drift. This adds a changelog and two CI gates.

## Changes

**`CHANGELOG.md`** (new) — [Keep a Changelog](https://keepachangelog.com) format, backfilled:
- `0.1.0` (2026-01-30, pyo3 0.27) — initial release.
- `0.2.0` (2026-05-29, pyo3 0.28) — flags the two breaking changes (pyo3 0.27→0.28 lockstep upgrade; MSRV 1.70→1.83).
- A **pyo3 ↔ pyo3-dlpack version table** explaining why consumers must match the `pyo3` minor version.

**`.github/workflows/ci.yml`** — two new jobs:
- `msrv`: `cargo check --all-features` on Rust 1.83 (the declared `rust-version`). Scoped to the library (no `--all-targets`) so dev-deps like criterion don't inflate the MSRV signal.
- `semver`: `cargo-semver-checks` vs the latest crates.io release — fails if a change is more breaking than the version bump implies.

## Verification

- `cargo check --all-features` passes on both stable and a freshly installed **Rust 1.83** (ran locally).
- `ci.yml` validated as well-formed YAML.
- `semver` job not run locally (needs the crates.io baseline + rustdoc); this PR only adds CI/docs with no `src/` changes, so it's purely additive vs the 0.2.0 baseline.

## Notes

- When an intentional breaking change lands later (e.g. the versioned-DLPack work in #7), the `semver` job will fail until the version is bumped to the matching level (under 0.x, breaking = minor). That's the intended behavior.
- Remember to move `Unreleased` entries under the new version and update the compare links at each release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)