### PR TITLE
release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 >
 > | pyo3-dlpack | pyo3   |
 > | ----------- | ------ |
+> | 0.3.x       | 0.28   |
 > | 0.2.x       | 0.28   |
 > | 0.1.x       | 0.27   |
 
 ## [Unreleased]
+
+## [0.3.0] - 2026-05-31
 
 ### Security
 - Raised the `pytest` floor in the `test`/`test-lite` extras from `>=7.0` to
@@ -67,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and devices (CPU, CUDA, CUDA host, ROCm, Metal, Vulkan, …).
 - Rust (criterion) and Python benchmarks; unit + integration test suite.
 
-[Unreleased]: https://github.com/isPANN/pyo3-dlpack/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/isPANN/pyo3-dlpack/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/isPANN/pyo3-dlpack/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/isPANN/pyo3-dlpack/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/isPANN/pyo3-dlpack/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-dlpack"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["isPANN"]
 description = "Zero-copy DLPack tensor interop for PyO3"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-pyo3-dlpack = "0.2"
+pyo3-dlpack = "0.3"
 pyo3 = "0.28"
 ```
 


### PR DESCRIPTION
## Release v0.3.0

Minor bump (`0.2.0` → `0.3.0`) packaging the changes landed since `0.2.0`.

### Why 0.3.0 and not 1.0
`pyo3` is a **public dependency** still in `0.x`, and every breaking `pyo3` release forces a breaking release here. Committing to a `1.0` SemVer guarantee while coupled to a pre-1.0 dependency would mean churning the major version on every `pyo3` bump. Staying in `0.x` (in lockstep with `pyo3`, like `rust-numpy`) is the honest signal until `pyo3` itself reaches `1.0`.

### Included since 0.2.0
- **Added:** versioned DLPack 1.0 support — `from_pyany`/`from_capsule` negotiate `max_version` and accept both `dltensor` and `dltensor_versioned` capsules; new `PyTensor::is_read_only()`, `IntoDLPack::into_dlpack_readonly`, versioned FFI types/constants. All additive — `into_dlpack` unchanged.
- **Security:** raised the `pytest` floor in the `test`/`test-lite` extras to `>=9.0.3` (CVE-2025-71176, CVE-2026-4539). Test-only; not shipped with the crate.
- **CI:** MSRV (1.83) job and `cargo-semver-checks` job.

### Release mechanics
- `Cargo.toml`, `Cargo.lock`, `README`, `CHANGELOG` bumped to `0.3.0`.
- `cargo build` / `clippy -D warnings` / `fmt --check` clean; `cargo publish --dry-run` packages cleanly.
- After merge, tagging `v0.3.0` triggers the Release workflow (crates.io publish + GitHub release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)